### PR TITLE
Allow saving executable file without specifying two flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,12 @@ Optitons:
     -h              Show this help message
     -i              Interactive compilation
     -nr             No Running after Compilation (only compile)
-    -o=<file>       Set executable file name (default: 'program')
-    -s              Save executable file
+    -o=<path>       Set the path where to save the executable file
     -so             Save output file (compilation running output contents, default: 'output.txt')
     
 Examples:
     gcpr -h
-    gcpr -s -o=run_me *.c
+    gcpr -o=run_me *.c
     gcpr -y -nr main.cpp utils.cpp
 ```
 

--- a/gcpr.py
+++ b/gcpr.py
@@ -169,6 +169,9 @@ def main_compilation(files: list, extension: str, flags: list):
     if (any(exe_flags)):
         # Get the executable_name from the first flag (discard others)
         _, executable_filename = exe_flags[0].split(FLAG_EXE_FILE_SET)
+    # Make sure default doesn't overwrite anything
+    elif (os.path.exists(DEFAULT_EXE_FILE_NAME)):
+        raise_msg(f"Error: File '{DEFAULT_EXE_FILE_NAME}' already exists.", CODE_ERROR)
 
     # Run the compilation
     compile_command = [COMPILATIONS[extension], *files, f"{FLAG_PREFIX}{FLAG_EXE_FILE}", executable_filename]


### PR DESCRIPTION
If a user want to save the executable produced by the script, they would have to to specify both the save flag and both the filename flag. I don't see a lot of reasons why anyone would want to specify the filename, without saving the file.

This pull request merges the two flags into one, saving when the filename flag is present.
It also makes sure not to overwrite users file with the executable implicitly.